### PR TITLE
Fix TypeScript errors for locale messages

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,1 +1,6 @@
 declare var $0: HTMLElement;
+
+interface Window {
+  initialized?: boolean;
+  fetchAndRender?: () => void;
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -13,6 +13,13 @@ export const messages = {
   observableName: "Name",
   observableType: "Type",
   observableValue: "Value",
+  dependencies: "Dependencies",
+  edit: "Edit",
+  searchPlaceholder: "Search observables...",
+  filterAll: "All types",
+  filterObservable: "Observable",
+  filterObservableArray: "Observable Array",
+  filterComputed: "Computed",
 
   // Settings
   settings: "Settings",
@@ -25,7 +32,14 @@ export const messages = {
   dataFormatPretty: "Pretty",
   showTypes: "Show Types",
   autoRefresh: "Auto-refresh",
+  realTimeMonitoring: "Real-time monitoring",
   language: "Language",
   saveSettings: "Save Settings",
   settingsSaved: "Settings saved successfully!",
+  errorUpdatingObservable: "Error updating observable",
+  observableUpdated: "Observable updated successfully",
+  editArray: "Edit Array",
+  cancel: "Cancel",
+  save: "Save",
+  invalidArrayFormat: "Invalid array format. Please enter a valid JSON array.",
 };

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -13,6 +13,13 @@ export const messages = {
   observableName: "Nom",
   observableType: "Type",
   observableValue: "Valeur",
+  dependencies: "Dépendances",
+  edit: "Modifier",
+  searchPlaceholder: "Rechercher des observables...",
+  filterAll: "Tous les types",
+  filterObservable: "Observable",
+  filterObservableArray: "Tableau observable",
+  filterComputed: "Calculé",
 
   // Settings
   settings: "Paramètres",
@@ -25,7 +32,14 @@ export const messages = {
   dataFormatPretty: "Détaillé",
   showTypes: "Afficher les types",
   autoRefresh: "Actualisation automatique",
+  realTimeMonitoring: "Surveillance en temps réel",
   language: "Langue",
   saveSettings: "Enregistrer les paramètres",
   settingsSaved: "Paramètres enregistrés avec succès !",
+  errorUpdatingObservable: "Erreur lors de la mise à jour de l'observable",
+  observableUpdated: "Observable mise à jour avec succès",
+  editArray: "Modifier le tableau",
+  cancel: "Annuler",
+  save: "Enregistrer",
+  invalidArrayFormat: "Format de tableau invalide. Veuillez entrer un tableau JSON valide.",
 };


### PR DESCRIPTION
## Summary
- expand Window interface for custom panel fields
- add missing localization strings in English and French locales

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af358410c8326a0b7bf67973a0314