### PR TITLE
Improve devtools sidebar UI

### DIFF
--- a/devtools/sidebar.html
+++ b/devtools/sidebar.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>KnockoutJS Context</title>
+<style>
+body {
+    font-family: sans-serif;
+    margin: 0;
+    padding: 10px;
+    background-color: #f9f9f9;
+    color: #333;
+}
+.section {
+    margin-bottom: 12px;
+}
+h2 {
+    margin: 0 0 4px 0;
+    font-size: 14px;
+}
+pre {
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 8px;
+    overflow: auto;
+    white-space: pre-wrap;
+}
+.copy-btn {
+    margin-left: 6px;
+    font-size: 11px;
+    padding: 2px 6px;
+}
+</style>
+</head>
+<body>
+<div class="section">
+  <h2>View Model <button class="copy-btn" data-target="view-model">Copy</button></h2>
+  <pre id="view-model"></pre>
+</div>
+<div class="section">
+  <h2>Context <button class="copy-btn" data-target="context">Copy</button></h2>
+  <pre id="context"></pre>
+</div>
+<script src="/dist/sidebar.js"></script>
+</body>
+</html>

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,51 +1,6 @@
-/**
- * Retrieves data and context for a Knockout.js view model.
- * @returns {object} Object containing the view model data and context.
- */
-const getKODataAndContext = function () {
-    if ((window as any).ko) {
-        let data = (window as any).ko && ($0 as any) ? (ko as any).dataFor($0) : {};
-        let context = (window as any).ko && ($0 as any) ? (ko as any).contextFor($0) : {};
-
-        if (data === null || data === undefined) {
-            data = {};
-        }
-
-        if (context === null || context === undefined) {
-            context = {};
-        }
-
-        let dataProps = Object.getOwnPropertyNames(data);
-        let contextProps = Object.getOwnPropertyNames(context);
-        let _data: { [key: string]: any } = Object.create(null);
-        let _context: { [key: string]: any } = Object.create(null);
-
-        for (let i = 0; i < dataProps.length; ++i) {
-            _data[dataProps[i]] = data[dataProps[i]];
-        }
-
-        for (let i = 0; i < contextProps.length; ++i) {
-            _context[contextProps[i]] = context[contextProps[i]];
-        }
-
-        return { viewModel: _data, context: _context };
-    }
-    return { viewModel: {}, context: {} };
-};
-
 chrome.devtools.panels.elements.createSidebarPane(
     'KnockoutJS Context',
-    function (sidebar) {
-        function updateElementProperties() {
-            try {
-                sidebar.setExpression('(' + getKODataAndContext.toString() + ')()');
-            } catch (error) {
-                console.error('Error updating element properties: ', error);
-            }
-        }
-        updateElementProperties();
-        chrome.devtools.panels.elements.onSelectionChanged.addListener(
-            updateElementProperties
-        );
+    function (sidebar: any): void {
+        sidebar.setPage('/devtools/sidebar.html');
     }
 );

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,1 +1,3 @@
 declare var $0: HTMLElement;
+declare var chrome: any;
+declare var ko: any;

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,0 +1,63 @@
+const getKODataAndContext = function () {
+    if ((window as any).ko) {
+        let data = (window as any).ko && ($0 as any) ? (ko as any).dataFor($0) : {};
+        let context = (window as any).ko && ($0 as any) ? (ko as any).contextFor($0) : {};
+
+        if (data === null || data === undefined) {
+            data = {};
+        }
+
+        if (context === null || context === undefined) {
+            context = {};
+        }
+
+        let dataProps = Object.getOwnPropertyNames(data);
+        let contextProps = Object.getOwnPropertyNames(context);
+        let _data: { [key: string]: any } = Object.create(null);
+        let _context: { [key: string]: any } = Object.create(null);
+
+        for (let i = 0; i < dataProps.length; ++i) {
+            _data[dataProps[i]] = data[dataProps[i]];
+        }
+
+        for (let i = 0; i < contextProps.length; ++i) {
+            _context[contextProps[i]] = context[contextProps[i]];
+        }
+
+        return { viewModel: _data, context: _context };
+    }
+    return { viewModel: {}, context: {} };
+};
+
+function updateData(): void {
+    chrome.devtools.inspectedWindow.eval('(' + getKODataAndContext.toString() + ')()', (result: any, error: any) => {
+        if (error) {
+            console.error('Error retrieving Knockout data:', error);
+            return;
+        }
+        const vmEl = document.getElementById('view-model');
+        const ctxEl = document.getElementById('context');
+        if (vmEl) {
+            vmEl.textContent = JSON.stringify(result.viewModel, null, 2);
+        }
+        if (ctxEl) {
+            ctxEl.textContent = JSON.stringify(result.context, null, 2);
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    updateData();
+    const buttons = document.querySelectorAll<HTMLButtonElement>('.copy-btn');
+    buttons.forEach((btn: HTMLButtonElement) => {
+        btn.addEventListener('click', () => {
+            const targetId = btn.getAttribute('data-target');
+            const target = targetId ? document.getElementById(targetId) : null;
+            if (target) {
+                navigator.clipboard.writeText(target.textContent || '');
+            }
+        });
+    });
+});
+
+chrome.devtools.panels.elements.onSelectionChanged.addListener(updateData);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,9 +6,10 @@ module.exports = (env, argv) => {
 	const isProduction = argv.mode === 'production';
 
 	return {
-		entry:        {
-			devtools: './src/devtools.ts',
-		},
+                entry:        {
+                        devtools: './src/devtools.ts',
+                        sidebar: './src/sidebar.ts',
+                },
 		output:       {
 			path:     path.resolve(__dirname, 'dist'),
 			filename: '[name].js',


### PR DESCRIPTION
## Summary
- add a custom sidebar page with a simple JSON viewer
- update the devtools script to load the new page
- implement a script to update and copy Knockout data
- extend global declarations and webpack configuration

## Testing
- `npx tsc`
- `npm run build` *(fails: `webpack` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c28d02398832691726c660c418f4d