### PR TITLE
Improve clipboard support in devtools sidebar

### DIFF
--- a/devtools/sidebar.html
+++ b/devtools/sidebar.html
@@ -34,11 +34,11 @@ pre {
 </head>
 <body>
 <div class="section">
-  <h2>View Model <button class="copy-btn" data-target="view-model">Copy</button></h2>
+  <h2>View Model <button class="copy-btn" data-target="view-model" title="Copy to clipboard">Copy</button></h2>
   <pre id="view-model"></pre>
 </div>
 <div class="section">
-  <h2>Context <button class="copy-btn" data-target="context">Copy</button></h2>
+  <h2>Context <button class="copy-btn" data-target="context" title="Copy to clipboard">Copy</button></h2>
   <pre id="context"></pre>
 </div>
 <script src="/dist/sidebar.js"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "version": "1.0",
   "description": "Uses the devtools API to add a sidebar that displays the Knockout data associated with the selected DOM element.",
   "devtools_page": "/devtools/devtools.html",
+  "permissions": ["clipboardWrite"],
   "icons": {
     "16": "images/icon-16.png",
     "32": "images/icon-32.png",

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -53,8 +53,18 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.addEventListener('click', () => {
             const targetId = btn.getAttribute('data-target');
             const target = targetId ? document.getElementById(targetId) : null;
-            if (target) {
-                navigator.clipboard.writeText(target.textContent || '');
+            if (target && navigator.clipboard) {
+                navigator.clipboard.writeText(target.textContent || '')
+                    .then(() => {
+                        const original = btn.textContent;
+                        btn.textContent = 'Copied!';
+                        setTimeout(() => {
+                            if (original) {
+                                btn.textContent = original;
+                            }
+                        }, 1000);
+                    })
+                    .catch((err) => console.error('Failed to copy text:', err));
             }
         });
     });


### PR DESCRIPTION
## Summary
- add clipboardWrite permission for the extension
- show copy hints on buttons and confirm copy

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c32fab24c8326a5bb86575d006ae2